### PR TITLE
Placeholder not always displaying

### DIFF
--- a/GCPlaceholderTextView/GCPlaceholderTextView.m
+++ b/GCPlaceholderTextView/GCPlaceholderTextView.m
@@ -60,11 +60,20 @@
     return text;
 }
 
-- (void) setText:(NSString *)text { 
-    super.text = text; 
+- (void) setText:(NSString *)text {
+    if ([text isEqualToString:@""] || text == nil) {
+        super.text = self.placeholder;
+    }
+    else {
+        super.text = text;
+    }
     
-    if ([text isEqualToString:self.placeholder]) self.textColor = [UIColor lightGrayColor];
-    else self.textColor = self.realTextColor;
+    if ([text isEqualToString:self.placeholder]) {
+        self.textColor = [UIColor lightGrayColor];
+    }
+    else {
+        self.textColor = self.realTextColor;
+    }
 }
 
 - (NSString *) realText {
@@ -73,14 +82,14 @@
 
 - (void) beginEditing:(NSNotification*) notification {
     if ([self.realText isEqualToString:self.placeholder]) {
-        self.text = nil;
+        super.text = nil;
         self.textColor = self.realTextColor;
     }
 }
 
 - (void) endEditing:(NSNotification*) notification {
     if ([self.realText isEqualToString:@""] || self.realText == nil) {
-        self.text = self.placeholder;
+        super.text = self.placeholder;
         self.textColor = [UIColor lightGrayColor];
     }
 }


### PR DESCRIPTION
Fixed issue of placeholder not displaying when setting text to nil or empty

Added additional logic to the setText method to handle both nil and empty.  This required an additional change to begin/end editing to set text via super.text instead of self.text.
