### PR TITLE
Added placeholderColor attribute to allow custom color for placeholderText

### DIFF
--- a/Demo/GCPlaceholderTextViewDemo.xcodeproj/project.pbxproj
+++ b/Demo/GCPlaceholderTextViewDemo.xcodeproj/project.pbxproj
@@ -141,7 +141,7 @@
 		B0B559EC1361DFFA00A8E980 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0420;
+				LastUpgradeCheck = 0460;
 				ORGANIZATIONNAME = LittleKiwi;
 			};
 			buildConfigurationList = B0B559EF1361DFFA00A8E980 /* Build configuration list for PBXProject "GCPlaceholderTextViewDemo" */;
@@ -256,6 +256,7 @@
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "GCPlaceholderTextViewDemo/GCPlaceholderTextViewDemo-Prefix.pch";
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "GCPlaceholderTextViewDemo/GCPlaceholderTextViewDemo-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
@@ -269,6 +270,7 @@
 				COPY_PHASE_STRIP = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "GCPlaceholderTextViewDemo/GCPlaceholderTextViewDemo-Prefix.pch";
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "GCPlaceholderTextViewDemo/GCPlaceholderTextViewDemo-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				VALIDATE_PRODUCT = YES;

--- a/Demo/GCPlaceholderTextViewDemo/GCPlaceholderTextViewDemoViewController.m
+++ b/Demo/GCPlaceholderTextViewDemo/GCPlaceholderTextViewDemoViewController.m
@@ -15,6 +15,7 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
+    self.textView.placeholderColor = [UIColor redColor];
     self.textView.placeholder = NSLocalizedString(@"This is a placeholder",);
 }
 

--- a/GCPlaceholderTextView/GCPlaceholderTextView.h
+++ b/GCPlaceholderTextView/GCPlaceholderTextView.h
@@ -12,5 +12,6 @@
 @interface GCPlaceholderTextView : UITextView 
 
 @property(nonatomic, retain) NSString *placeholder;
+@property (nonatomic, retain) UIColor *placeholderColor;
 
 @end

--- a/GCPlaceholderTextView/GCPlaceholderTextView.m
+++ b/GCPlaceholderTextView/GCPlaceholderTextView.m
@@ -22,6 +22,7 @@
 
 @synthesize realTextColor;
 @synthesize placeholder;
+@synthesize placeholderColor;
 
 #pragma mark -
 #pragma mark Initialisation
@@ -38,6 +39,7 @@
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(endEditing:) name:UITextViewTextDidEndEditingNotification object:self];
     
     self.realTextColor = [UIColor blackColor];
+    self.placeholderColor = [UIColor lightGrayColor];
 }
 
 #pragma mark -
@@ -69,7 +71,7 @@
     }
     
     if ([text isEqualToString:self.placeholder]) {
-        self.textColor = [UIColor lightGrayColor];
+        self.textColor = self.placeholderColor;
     }
     else {
         self.textColor = self.realTextColor;
@@ -90,14 +92,17 @@
 - (void) endEditing:(NSNotification*) notification {
     if ([self.realText isEqualToString:@""] || self.realText == nil) {
         super.text = self.placeholder;
-        self.textColor = [UIColor lightGrayColor];
+        self.textColor = self.placeholderColor;
     }
 }
 
 - (void) setTextColor:(UIColor *)textColor {
     if ([self.realText isEqualToString:self.placeholder]) {
-        if ([textColor isEqual:[UIColor lightGrayColor]]) [super setTextColor:textColor];
-        else self.realTextColor = textColor;
+        if ([textColor isEqual:self.placeholderColor]){
+             [super setTextColor:textColor];
+        } else {
+            self.realTextColor = textColor;
+        }
     }
     else {
         self.realTextColor = textColor;


### PR DESCRIPTION
It still defaults to [UIColor lightGrayColor] in the initializer.

Also, updated the Xcode project file, which set the compiler to clang instead of gcc.
