### PR TITLE
Fix memory management issues

### DIFF
--- a/GCPlaceholderTextView/GCPlaceholderTextView.m
+++ b/GCPlaceholderTextView/GCPlaceholderTextView.m
@@ -49,9 +49,11 @@
     if ([self.realText isEqualToString:placeholder] && ![self isFirstResponder]) {
         self.text = aPlaceholder;
     }
+    if (aPlaceholder != placeholder) {
+        [placeholder autorelease];
+        placeholder = [aPlaceholder retain];
+    }
     
-    [placeholder release];
-    placeholder = [aPlaceholder retain];
     
     [self endEditing:nil];
 }
@@ -115,7 +117,9 @@
 
 - (void)dealloc {
     [realTextColor release];
+    realTextColor = nil;
     [placeholder release];
+    placeholder = nil;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     
     [super dealloc];


### PR DESCRIPTION
Got some crash reports from GCPlaceholderTextView -dealloc.

First change ensures that placeholder will not be corrupted when setting the same string (same pointer): If it has retain count == 1, then first release will dealloc the object, and retain will be sent to deallocated object.

Changes in dealloc are made to avoid having references to deallocated objects. Just in case.
