### PR TITLE
FIX: if text is nil we have to set textColor to placeholderColor otherwise placeholder text doesn´t have the right color

### DIFF
--- a/GCPlaceholderTextView/GCPlaceholderTextView.m
+++ b/GCPlaceholderTextView/GCPlaceholderTextView.m
@@ -79,7 +79,7 @@
         super.text = text;
     }
     
-    if ([text isEqualToString:self.placeholder]) {
+    if ([text isEqualToString:self.placeholder] || text == nil) {
         self.textColor = self.placeholderColor;
     }
     else {


### PR DESCRIPTION
I´m using GCPlaceholderTextView in a UITableViewCell, i set the placeholder like this:

```
SettingsTextViewCell *cell = (SettingsTextViewCell *) [tableView dequeueReusableCellWithIdentifier:@"SettingsTextViewCell"];
        if (!cell) {
            cell = (SettingsTextViewCell *) [[[NSBundle mainBundle] loadNibNamed:@"SettingsTextViewCell"
                                                                           owner:self
                                                                         options:nil] objectAtIndex:0];
        }
cell.textView.placeholder = @"placeholder";
.....
```

and the placeholder color was black. This addition fix the problem with the placeholder color.
