### PR TITLE
Improving placeholder behavior

### DIFF
--- a/GCPlaceholderTextView/GCPlaceholderTextView.m
+++ b/GCPlaceholderTextView/GCPlaceholderTextView.m
@@ -91,16 +91,28 @@
 }
 
 - (void) beginEditing:(NSNotification*) notification {
-    if ([self.realText isEqualToString:self.placeholder]) {
-        super.text = nil;
-        self.textColor = self.realTextColor;
-    }
+    self.selectedRange = NSMakeRange(0, 0);
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didChange:) name:UITextViewTextDidChangeNotification object:self];
 }
 
 - (void) endEditing:(NSNotification*) notification {
-    if ([self.realText isEqualToString:@""] || self.realText == nil) {
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:UITextViewTextDidChangeNotification object:self];
+}
+
+- (void) didChange:(NSNotification*) notification {
+    
+    if (self.realText.length)
+    {
+        if ([[self.realText substringFromIndex:1] isEqualToString:self.placeholder]) {
+            super.text = [self.realText substringToIndex:1];
+            self.textColor = self.realTextColor;
+        }
+    }
+    else
+    {
         super.text = self.placeholder;
         self.textColor = self.placeholderColor;
+        self.selectedRange = NSMakeRange(0, 0);
     }
 }
 

--- a/GCPlaceholderTextView/GCPlaceholderTextView.m
+++ b/GCPlaceholderTextView/GCPlaceholderTextView.m
@@ -53,7 +53,7 @@
     }
     
     
-    [self endEditing:nil];
+    [self didChange:nil];
 }
 
 - (void)setPlaceholderColor:(UIColor *)aPlaceholderColor {


### PR DESCRIPTION
Instead of disappearing with the placeholder text as soon as the textview begins editing now we wait for user input to replace it, just like the native behavior in UILabel and UITextField.

Tested in iOS 8.3
